### PR TITLE
Fix $pmux port order

### DIFF
--- a/src/ghdl.cc
+++ b/src/ghdl.cc
@@ -887,8 +887,8 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 		        {
 		            RTLIL::SigSpec b;
 			    RTLIL::SigSpec s = IN(0);
-			    for (unsigned i = s.size(); i > 0; i--)
-				    b.append(IN(2 + i - 1));
+			    for (int i = 0; i < s.size(); i++)
+				    b.append(IN(2 + i));
 			    module->addPmux(to_str(iname), IN(1), b, s, OUT(0));
 			}
 			break;

--- a/testsuite/formal/gates/test_pmux.sby
+++ b/testsuite/formal/gates/test_pmux.sby
@@ -1,0 +1,12 @@
+[options]
+mode prove
+
+[engines]
+smtbmc z3
+
+[script]
+ghdl --std=08 test_pmux.vhd -e ent
+prep -top ent
+
+[files]
+test_pmux.vhd

--- a/testsuite/formal/gates/test_pmux.vhd
+++ b/testsuite/formal/gates/test_pmux.vhd
@@ -1,0 +1,46 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ent is
+	port (
+		clk : in std_logic;
+		a : in std_logic_vector(1 downto 0);
+		b : out std_logic_vector(1 downto 0)
+	);
+end entity;
+
+architecture a of ent is
+begin
+	process(clk)
+	begin
+		if rising_edge(clk) then
+			case a is
+				when "00" =>
+					b <= "01";
+				when "01" =>
+					b <= "10";
+				when "11" =>
+					b <= "00";
+				when others =>
+					b <= "11";
+			end case;
+		end if;
+	end process;
+
+	formal: block
+		signal has_run : std_logic := '0';
+		signal prev_a : std_logic_vector(1 downto 0);
+	begin
+		process(clk)
+		begin
+			if rising_edge(clk) then
+				prev_a <= a;
+				has_run <= '1';
+			end if;
+		end process;
+
+		default clock is rising_edge(clk);
+		assert always has_run -> unsigned(prev_a) + 1 = unsigned(b);
+	end block;
+end architecture;

--- a/testsuite/formal/gates/testsuite.sh
+++ b/testsuite/formal/gates/testsuite.sh
@@ -3,7 +3,7 @@
 topdir=../..
 . $topdir/testenv.sh
 
-for f in abs minmax lsl lsr asr; do
+for f in abs minmax pmux lsl lsr asr; do
   formal "test_${f}"
 done
 


### PR DESCRIPTION
- for `Id_Pmux`, `IN(2+n)` corresponds to `s(n)`.
- for `$pmux`, `B[n*WIDTH-1:(n-1)*WIDTH]` corresponds to `S[n]`.

Therefore, the inputs need to be appended to the data vector in ascending order, such that `IN(2)` is assigned to `B[WIDTH-1:0]`, `IN(3)` to `B[2*WIDTH-1:WIDTH]`, etc.
