### PR TITLE
Add reduce_xor support to the Yosys plugin

### DIFF
--- a/src/ghdl.cc
+++ b/src/ghdl.cc
@@ -663,6 +663,7 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 		case Id_Abs:
 		case Id_Red_Or:
 		case Id_Red_And:
+		case Id_Red_Xor:
 		case Id_Lsr:
 		case Id_Lsl:
 		case Id_Asr:
@@ -839,6 +840,9 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 			break;
 		case Id_Red_And:
 			module->addReduceAnd(to_str(iname), IN(0), OUT(0));
+			break;
+		case Id_Red_Xor:
+			module->addReduceXor(to_str(iname), IN(0), OUT(0));
 			break;
 		case Id_Lsl:
 			module->addShl(to_str(iname), IN(0), IN(1), OUT(0));


### PR DESCRIPTION
This is a followup for [ghdl/ghdl issue 1342](https://github.com/ghdl/ghdl/issues/1342).

`ghdl --synth` works correctly for the `test_unop.vhd` testcase within, but the plugin fails to properly import the `$red_xor` cell:

```
yosys> ghdl --std=08 test_unop.vhd -e test_unop
1. Executing GHDL.
Importing module test_unop.
ERROR: Unsupported(1): instance \14 of $red_xor.
ERROR: Assert `GetSize(ports) >= it.second->port_id' failed in kernel/rtlil.cc:1416.
```

This pull request adds to the case statements of the plugin to allow the XOR reduce operator to be imported correctly.