### PR TITLE
Fix testsuite failing on second run

### DIFF
--- a/testsuite/ghdl-issues/issue1309b/testsuite.sh
+++ b/testsuite/ghdl-issues/issue1309b/testsuite.sh
@@ -3,7 +3,7 @@
 topdir=../..
 . $topdir/testenv.sh
 
-run_symbiyosys -d work/psl_test psl_test.sby prove
+run_symbiyosys -fd work/psl_test psl_test.sby prove
 
 clean
 echo OK


### PR DESCRIPTION
Without `-f`, symbiyosys fails to run if the directory already exists.