### PR TITLE
Debian patches regarding DESTDIR and plugin install dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LIBGHDL_LIB:=$(shell $(GHDL) --libghdl-library-path)
 LIBGHDL_INC:=$(shell $(GHDL) --libghdl-include-dir)
 
 ALL_LDFLAGS=$(LIBGHDL_LIB) -Wl,-rpath,$(dir $(LIBGHDL_LIB)) $(LDFLAGS)
+DATDIR:=$(shell $(YOSYS_CONFIG) --datdir)
 
 ALL_CFLAGS=-fPIC -DYOSYS_ENABLE_GHDL -I$(LIBGHDL_INC) $(CFLAGS)
 
@@ -29,8 +30,8 @@ clean: force
 	$(RM) -f ghdl.$(SOEXT) ghdl.o
 
 install: ghdl.$(SOEXT)
-	$(YOSYS_CONFIG) --exec mkdir -p --datdir/plugins
-	$(YOSYS_CONFIG) --exec cp $< --datdir/plugins
+	$(YOSYS_CONFIG) --exec mkdir -p $(DESTDIR)$(DATDIR)/plugins
+	$(YOSYS_CONFIG) --exec cp $< $(DESTDIR)$(DATDIR)/plugins
 
 -include src/ghdl.d
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LIBGHDL_LIB:=$(shell $(GHDL) --libghdl-library-path)
 LIBGHDL_INC:=$(shell $(GHDL) --libghdl-include-dir)
 
 ALL_LDFLAGS=$(LIBGHDL_LIB) -Wl,-rpath,$(dir $(LIBGHDL_LIB)) $(LDFLAGS)
-DATDIR:=$(shell $(YOSYS_CONFIG) --datdir)
+PLUGINDIR:=$(shell $(YOSYS_CONFIG) --datdir)/plugins
 
 ALL_CFLAGS=-fPIC -DYOSYS_ENABLE_GHDL -I$(LIBGHDL_INC) $(CFLAGS)
 
@@ -30,8 +30,8 @@ clean: force
 	$(RM) -f ghdl.$(SOEXT) ghdl.o
 
 install: ghdl.$(SOEXT)
-	$(YOSYS_CONFIG) --exec mkdir -p $(DESTDIR)$(DATDIR)/plugins
-	$(YOSYS_CONFIG) --exec cp $< $(DESTDIR)$(DATDIR)/plugins
+	$(YOSYS_CONFIG) --exec mkdir -p $(DESTDIR)$(PLUGINDIR)
+	$(YOSYS_CONFIG) --exec cp $< $(DESTDIR)$(PLUGINDIR)
 
 -include src/ghdl.d
 


### PR DESCRIPTION
Support installing into $DESTDIR

This makes packaging easier for distributions as installation is usually
staged in a temporary directory when building intallable packages.

---

Allow overriding plugin installation directory

Currently we install the plugin into /usr/share since this is where yosys
loads from, however this violates the FHS as only architecture-independent
data is supposed to be installed in share.

Until this is reolved properly at least allow overriding the plugin
installation directory explicitly using make variables on the command line.

See YosysHQ/yosys#3151