### PR TITLE
fixed VLO/VHI primitves

### DIFF
--- a/library/wrapper/primitives.v
+++ b/library/wrapper/primitives.v
@@ -1,13 +1,13 @@
 `timescale 1 ns / 1 ps
 
-module vhi ( z );
-    output z ;
-  supply1 VSS;
-  buf (z , VSS);
-endmodule 
+module VHI ( Z );
+  output Z ;
+  supply1 VDD;
+  buf (Z , VDD);
+endmodule
 
-module vlo ( z );
-	output z;
-  supply1 VSS;
-  buf (z , VSS);
+module VLO ( Z );
+  output Z;
+  supply0 VSS;
+  buf (Z , VSS);
 endmodule


### PR DESCRIPTION
This is in regards to #184.

**Changes**:

- changed VLO and VHI declaration capitalisation. Verilog is case-sensitive thus the modules couldn't be found by nextpnr even though yosys had no problem generating RTL
- changed VLO to use a `supply0` instead of a `supply1`. As per the Lattice FPGA Library reference ([PDF Download](https://www.latticesemi.com/~/media/LatticeSemi/Documents/UserManuals/EI/FPGALibrariesReferenceGuide32.pdf?document_id=50687)) VLO is supposed to output a logic 0 (PDF Page 705f.)
- changed VHI's `supply1` net name from `VSS` to `VDD` to avoid any confusion

The ecp5_versa example (with modified makefile to use local tools instead of docker) compiles successfully with these changes.
