### PR TITLE
Skip sby tests when unavailable

### DIFF
--- a/testsuite/testenv.sh
+++ b/testsuite/testenv.sh
@@ -36,6 +36,10 @@ run_yosys ()
 
 run_symbiyosys ()
 {
+    if ! command -v $SYMBIYOSYS >/dev/null; then
+         echo>&2 "Warning: sby unavailable, remaining tests skipped"
+         exit
+    fi
     cmd $SYMBIYOSYS --yosys "$YOSYS" "$@"
 }
 


### PR DESCRIPTION
We don't have sby in Debian yet so we need to skip tests using it there.

Note this does use `exit` to bail out of the current test script entirely so we need to be careful not to have non-sby tests after one using sby.