### PR TITLE
Fix host of HDL containers

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -42,7 +42,7 @@ do_plugin () {
 gstart "[Build] ghdl/synth:beta" "$ANSI_MAGENTA"
 
 docker build -t ghdl/synth:beta . -f- <<-EOF
-ARG REGISTRY='gcr.io/hdl-containers/debian/bullseye'
+ARG REGISTRY='ghcr.io/hdl/debian/bullseye'
 
 #---
 
@@ -88,7 +88,7 @@ do_formal () {
 gstart "[Build] ghdl/synth:formal" "$ANSI_MAGENTA"
 
 docker build -t ghdl/synth:formal . -f- <<-EOF
-ARG REGISTRY='gcr.io/hdl-containers/debian/bullseye'
+ARG REGISTRY='ghcr.io/hdl/debian/bullseye'
 
 #--
 


### PR DESCRIPTION
Hi @tgingold!

As shown in the latest workflow:

- https://github.com/ghdl/ghdl-yosys-plugin/actions/runs/12510093997/job/34900417538

The CI is failing because the HDL containers were removed from Google Cloud.

This PR updates the host from `gcr.io` to `ghcr.io`.

Cheers and Merry Christmas! :smiley: :partying_face: 

---

/cc @umarcor 