### PR TITLE
README.md: Use of hdlmake to replace sources analysis stage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Alternatively, it is possible to analyze, elaborate and synthesize VHDL sources 
 yosys $MODULE -p 'ghdl leds.vhdl spin1.vhdl -e leds; synth_ice40 -json leds.json'
 ```
 
+Finally, one may avoid analysis of individual source files in complex projects with help of [hdlmake](https://gitlab.com/ohwr/project/hdl-make)
+
+```
+cd examples/icestick/leds/
+hdlmake -f Makefile.mk
+make -f Makefile.mk
+```
+
 ## Containers
 
 Container (aka Docker/Podman) image [`hdlc/ghdl:yosys`](https://hub.docker.com/r/hdlc/ghdl/tags) includes GHDL, Yosys and the ghdl-yosys-plugin module (shared library). These can be used to synthesize designs straightaway. For example:

--- a/examples/icestick/leds/Manifest.py
+++ b/examples/icestick/leds/Manifest.py
@@ -1,0 +1,15 @@
+action = "simulation"
+sim_tool = "ghdl"
+sim_top = "leds"
+ghdl_opt = "--std=08 --ieee=standard "
+module = "-m ghdl.so"
+sim_post_cmd = (
+    "yosys {} -p 'ghdl --work=work {} leds; synth_ice40  -json leds.json'".format(
+        module, ghdl_opt
+    )
+)
+
+files = [
+    "leds.vhdl",
+    "spin1.vhdl",
+]


### PR DESCRIPTION
Hdlmake may be used to perform analysis of project sources, before synthesis.

This modification shows how, with a simple example.